### PR TITLE
paper_downloader: Search on Selected Text, More sources, Better DOI detecting, and bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Addons:
 ### -`paper_downloader`
 Download the paper name under cursor from google scholar or scihub and open the document. To enable add this to your `prefs_user.config`:
 ```
-new_command _download_paper python -m sioyek.paper_downloader download "%{sioyek_path}" "%{paper_name}"
+new_command _download_paper python -m sioyek.paper_downloader download "%{sioyek_path}" "%{selected_text}" "%{paper_name}" [Your Email, If Ssing Unpaywall]
 control_click_command _download_paper
 ```
 Now you can download papers by control-clicking on their names like this:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Addons:
 ### -`paper_downloader`
 Download the paper name under cursor from google scholar or scihub and open the document. To enable add this to your `prefs_user.config`:
 ```
-new_command _download_paper python -m sioyek.paper_downloader download "%{sioyek_path}" "%{selected_text}" "%{paper_name}" [Your Email, If Ssing Unpaywall]
+new_command _download_paper python -m sioyek.paper_downloader download "%{sioyek_path}" "%{paper_name}" "%{selected_text}" [Your Email, If Using Unpaywall]
 control_click_command _download_paper
 ```
 Now you can download papers by control-clicking on their names like this:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
   "pyperclip  >= 1.8",
   "habanero >= 1.2.2",
   "regex >= 2.5.83",
-  "PyQt5 >= 5.15"
+  "PyQt5 >= 5.15",
+  "libgen-api >= 1.0.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "sioyek"
 version = "0.31.10"
 authors = [
   { name="Ali Mostafavi", email="a.hr.mostafavi@gmail.com" },
+  { name="Garrett Credi", email="garrettcredi@gmail.com" }
 ]
 description = "Python tools and extensions for sioyek PDF reader"
 readme = "README.md"
@@ -27,7 +28,8 @@ dependencies = [
   "habanero >= 1.2.2",
   "regex >= 2.5.83",
   "PyQt5 >= 5.15",
-  "libgen-api >= 1.0.0"
+  "libgen-api >= 1.0.0",
+  "python-slugify >= 8.0.1"
 ]
 
 [project.urls]

--- a/src/sioyek/paper_downloader.py
+++ b/src/sioyek/paper_downloader.py
@@ -304,7 +304,9 @@ def download_paper_with_doi(doi_string, paper_name, doi_map):
             if len(pdf_files) > 0:
                 returned_file = download_dir / pdf_files[0]
                 pdf_path = str(returned_file)
-                clean_path = clean_pdf_name(pdf_path)
+                filename, ext = os.path.splitext(pdf_path)
+                pdf_path_with_method = f"{filename}-{method_name}{ext}"
+                clean_path = clean_pdf_name(pdf_path_with_method)
                 if clean_path != pdf_path:
                     shutil.move(pdf_path, clean_path)
                 doi_map[doi_string] = clean_path

--- a/src/sioyek/paper_downloader.py
+++ b/src/sioyek/paper_downloader.py
@@ -329,8 +329,8 @@ if __name__ == '__main__':
     mode = sys.argv[1]
     SIOYEK_PATH = clean_path(sys.argv[2])
     sioyek = Sioyek(SIOYEK_PATH)
-    selected = sys.argv[3]
-    parsed = sys.argv[4]
+    parsed = sys.argv[3]
+    selected = sys.argv[4]
 
     paper_name = ""
     chose_paper = False

--- a/src/sioyek/paper_downloader.py
+++ b/src/sioyek/paper_downloader.py
@@ -330,13 +330,16 @@ if __name__ == '__main__':
     SIOYEK_PATH = clean_path(sys.argv[2])
     sioyek = Sioyek(SIOYEK_PATH)
     parsed = sys.argv[3]
-    selected = sys.argv[4]
+    selected = ""
+
+    if len(sys.argv) > 4:
+        selected = sys.argv[4]
 
     paper_name = ""
     chose_paper = False
-    if len(selected) != 2:
+    if len(selected) > 2:
         paper_name = selected
-    elif len(parsed) != 2:
+    elif len(parsed) > 2:
         paper_name = parsed
         chose_paper = True
 


### PR DESCRIPTION
This is a substantial PR, some of which is a breaking change and other parts improve the reliability and functionality.

In terms of breaking changes, this PR modifies the arguments that `sioyek.paper_downloader` expects, especially when being called from `prefs_user.config`. While originally it expected to have `[mode] [sioyek_path] [paper_name]` as `sys.argv` this version now expects `[mode] [sioyek_path] [paper_name] [selected_text] [User Email, If Using Unpaywall]`. However, the final two arguments are optional.

This is because there is now support for downloading a paper based on a name as selected by the user, so if the user tries the default method and it either fails or brings up the wrong paper name, they can select the correct region themselves to query a DOI against.

Either the paper name or selected text is sent to the improved DOI parser which chooses the best match of the predicted title of the paper (useful if the user includes authors to help query) out of all those that Crossref returns.

The major improvement is when it gets sent to `download_paper_with_doi`, which now does *not* check against Google Scholar, as it is far too easy to hit the rate limit, but instead gets sent to Unpaywall, Crossref, and possibly Libgen if it is determined to be a textbook. It is still sent to Scihub.

Finally, it could be the case that the downloaded PDF has characters that Sioyek does not like treating as a file name (this came up when I was trying to download papers with astericks and greek letters in their titles) so it now uses `slugify` to parse it into a safe file name. For additional bugfixes, all calls to change sioyek's status are now guarded against the case where `sioyek == None`, making users able to use `paper_downloader` as a library.

There was also a bug where some requests to get PDF's, from links that Crossref or Unpaywall returned, errored due to Certificate validation bugs. My fix was to make all requests that download a PDF (on lines 192, 217 and 268) include the `verify = False` flag, which I don't think is the best way to handle it, so input especially for that case would be very useful.

I think I covered all of my changes, but if there are diff's that this blurb doesn't explain please feel free to ask me about them!