### PR TITLE
no quotations for %{selected_rect}

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ https://user-images.githubusercontent.com/6392321/205931274-ef2b20e5-0aec-478c-9
 
 Config:
 ```
-new_command _remove_annotations python -m sioyek.remove_annotation "%{sioyek_path}" "%{local_database}" "%{shared_database}" "%{file_path}" "%{selected_rect}"
+new_command _remove_annotations python -m sioyek.remove_annotation "%{sioyek_path}" "%{local_database}" "%{shared_database}" "%{file_path}" %{selected_rect}
 ```
 
 ### -`add_text`
@@ -95,8 +95,8 @@ https://user-images.githubusercontent.com/6392321/205931938-938da231-8f2c-4f85-9
 
 Config:
 ```
-new_command _add_text python -m sioyek.add_text "%{sioyek_path}" "%{local_database}" "%{shared_database}" "%{file_path}" "%{selected_rect}" "%{command_text}"
-new_command _add_red_text python -m sioyek.add_text "%{sioyek_path}" "%{local_database}" "%{shared_database}" "%{file_path}" "%{selected_rect}" "%{command_text}" fontsize=5 text_color=255,0,0
+new_command _add_text python -m sioyek.add_text "%{sioyek_path}" "%{local_database}" "%{shared_database}" "%{file_path}" %{selected_rect} "%{command_text}"
+new_command _add_red_text python -m sioyek.add_text "%{sioyek_path}" "%{local_database}" "%{shared_database}" "%{file_path}" %{selected_rect} "%{command_text}" fontsize=5 text_color=255,0,0
 ```
 
 


### PR DESCRIPTION
When using the commands with `%{selected_rect}` provided in the `README.md`, commands fail to work with below error.

```python
    QString::arg: Argument missing: python -m sioyek.remove_annotation "%{sioyek_path}" "%{local_database}" "%{shared_database}" "%{file_path}" "%{selected_rect}", /tmp/a.pdf
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/usr/lib/python3.10/site-packages/sioyek/remove_annotation.py", line 21, in <module>
    selected_page, selected_rect = parse_rect(rect_string)
  File "/usr/lib/python3.10/site-packages/sioyek/remove_annotation.py", line 7, in parse_rect
    page = int(parts[0])
ValueError: invalid literal for int() with base 10: '"0'
```

Changing the commands so that there are no quotations around the `%{selected_rect}` solve the issue.

