### PR TITLE
Fix unpacking errors triggered by _embed_annotations in get_bookmarks() and get_highlights() functions

### DIFF
--- a/src/sioyek/sioyek.py
+++ b/src/sioyek/sioyek.py
@@ -1167,8 +1167,12 @@ class Document:
 
         shared_database = self.sioyek.get_shared_database()
         cursor = shared_database.execute(HIGHLIGHT_SELECT_QUERY)
-        highlights = [Highlight(self, text, highlight_type, (begin_x, begin_y), (end_x, end_y)) for _, _, text, highlight_type, begin_x, begin_y, end_x, end_y in cursor.fetchall()]
-        return highlights
+        return [
+        Highlight(self, text, highlight_type, (begin_x, begin_y), (end_x, end_y))
+        for row in cursor.fetchall()
+        if len(row) >= 8
+        for _, _, text, highlight_type, begin_x, begin_y, end_x, end_y, *_ in [row]
+    ]
     
     def get_page_selection(self, page_number, selection_begin_x, selection_begin_y, selection_end_x, selection_end_y):
         in_range = False

--- a/src/sioyek/sioyek.py
+++ b/src/sioyek/sioyek.py
@@ -1154,8 +1154,12 @@ class Document:
         BOOKMARK_SELECT_QUERY = "select * from bookmarks where document_path='{}'".format(doc_hash)
         shared_database = self.sioyek.get_shared_database()
         cursor = shared_database.execute(BOOKMARK_SELECT_QUERY)
-        bookmarks = [Bookmark(self, desc, y_offset) for _, _, desc, y_offset in cursor.fetchall()]
-        return bookmarks
+        return [
+        Bookmark(self, desc, y_offset)
+        for row in cursor.fetchall()
+        if len(row) >= 4
+        for _, _, desc, y_offset, *_ in [row]
+    ]
 
     def get_highlights(self):
         doc_hash = self.get_hash()


### PR DESCRIPTION
## Problem

When using the `_embed_annotations` , users may run into unpacking errors in the `get_bookmarks()` and `get_highlights()` functions inside `sioyek.py`.

These functions expect a fixed number of columns returned by SQLite queries. However, on some systems (e.g., Arch Linux with Python 3.12+), the database may return extra columns due to schema changes or environment-specific differences.

This can trigger errors like:

- `ValueError: too many values to unpack (expected 4)`
- `ValueError: too many values to unpack (expected 8)`

These issues break the `_embed_annotations` feature, which depends on both functions to extract highlights and bookmarks.

---

## What this PR does

- Replaces fixed unpacking with a more robust pattern that handles extra columns gracefully
- Uses length checks and wildcard unpacking (`*_`) to capture only the needed fields
- Preserves the original behavior using list comprehensions
- Makes `_embed_annotations` more reliable across environments

---

## Testing

- Verified `_embed_annotations` works correctly after adding highlights and bookmarks
- Tested with Sioyek installed via `pip` on Python 3.12
- Used a PDF with real annotations to confirm that `embed_annotations.py` runs successfully

---